### PR TITLE
 feat(client): Use npm if there is an npm lock file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "emma": "dist/index.js"
   },
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "release": {
     "branch": "master"
   },
@@ -53,8 +56,8 @@
     "cross-env": "^5.1.3",
     "eslint-config-xo-react": "^0.16.0",
     "eslint-plugin-react": "^7.7.0",
-    "xo": "^0.20.3",
-    "semantic-release": "^12.4.1"
+    "semantic-release": "^12.4.1",
+    "xo": "^0.20.3"
   },
   "xo": {
     "extends": "xo-react",

--- a/src/emma.js
+++ b/src/emma.js
@@ -310,12 +310,12 @@ class Emma extends Component {
       const isDev = this.props.dev
       const yarn = await shouldUseYarn()
       const env = yarn ? 'yarnpkg' : 'npm'
-      const arg = yarn ? 'add' : 'install --save'
+      const arg = yarn ? ['add'] : ['install', '--save']
       const devArg = yarn ? '-D' : '--save-dev'
 
       // Packages
       const packages = selectedPackages.map(pkg => pkg.name)
-      const args = [arg, ...packages, ...(isDev ? [devArg] : [])]
+      const args = [...arg, ...packages, ...(isDev ? [devArg] : [])]
 
       // Install the queries
 


### PR DESCRIPTION
I use `promisify` which was introduced in version 8 of node. If you want to support older versions we have to use [es6-promisify](https://www.npmjs.com/package/es6-promisify) or similar.

I also detected a bug; `install --save` was passed as one argument to npm which don't work, so I separated it into two arguments (`['install', '--save`]`).

Fixes: #8