### PR TITLE
Don’t explicitly color the “Search packages” text white

### DIFF
--- a/src/emma.js
+++ b/src/emma.js
@@ -85,7 +85,7 @@ const Package = pkg => (
 
 const Search = ({ value, onChange, onSubmit }) => (
    <div>
-      <Text bold white>
+      <Text bold>
          {`Search packages 📦  : `}
       </Text>
       <TextInput


### PR DESCRIPTION
Before (with a light theme):
<img width="306" alt="screen shot 2018-07-27 at 18 08 59" src="https://user-images.githubusercontent.com/25517624/43348509-62e9af92-91c8-11e8-82ad-9138385c5c83.png">
After:
<img width="306" alt="screen shot 2018-07-27 at 18 09 22" src="https://user-images.githubusercontent.com/25517624/43348511-631b0704-91c8-11e8-9226-a64b374ebb91.png">

