### PR TITLE
Move babel plugin to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "url": "https://github.com/maticzav/emma-cli/issues"
   },
   "dependencies": {
-    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.40",
     "algoliasearch": "^3.24.12",
     "apollo-cache-inmemory": "^1.2.10",
     "apollo-client": "^2.4.2",
@@ -61,6 +60,7 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.40",
     "@babel/core": "^7.0.0-beta.40",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.40",
     "@babel/preset-env": "^7.0.0-beta.40",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "cross-env": "^5.1.3",


### PR DESCRIPTION
Yarn and npm currently emits a warning that `@babel/plugin-proposal-object-rest-spread@7.0.0` has a unmet peer dependency on `@babel/core@^7.0.0-0`. Since it's only used upon transpilation, it has been moved to devDependencies.

This also avoids having to install the plugin and its dependencies when installing emma-cli.