### PR TITLE
fix: adjust prisma module path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,7 @@ FROM heroku/heroku:18
 RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - &&\
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&\
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list &&\
-    apt-get update -y && apt-get install -y nodejs 
-
-# Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&\
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list &&\
-    apt-get update -y && apt-get install -y gcc g++ make yarn
+    apt-get update -y && apt-get install -y nodejs gcc g++ make yarn
 
 WORKDIR /usr/src/app
 

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
     "prisma:migrate": "prisma2 lift up"
   },
   "dependencies": {
+    "@prisma/photon": "^2.0.0-preview018",
     "algoliasearch": "3.35.1",
     "crypto": "^1.0.1",
     "express": "4.17.1",
@@ -15,6 +16,7 @@
     "jsonwebtoken": "8.5.1",
     "lodash": "^4.17.15",
     "object-hash": "^2.0.1",
+    "prisma2": "^2.0.0-preview018",
     "probot": "9.6.6"
   },
   "devDependencies": {

--- a/server/schema.prisma
+++ b/server/schema.prisma
@@ -5,7 +5,6 @@ datasource pg {
 
 generator photon {
   provider = "photonjs"
-  output   = "./node_modules/@prisma/photon"
 }
 
 model Starter {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1530,6 +1530,11 @@
   dependencies:
     debug "^4.0.0"
 
+"@prisma/photon@^2.0.0-preview018":
+  version "2.0.0-preview018"
+  resolved "https://registry.yarnpkg.com/@prisma/photon/-/photon-2.0.0-preview018.tgz#65698a5da5aa83874058893ad681a814f72e015e"
+  integrity sha512-XZR27e0gwpQzkUCMWGtR2DGPInLCPyGt8ZBDObmwMfUn7zlEN7zo0gFcTraAeeceJxlEPcDNU6NG3TZyu6cQew==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -7338,10 +7343,10 @@ pretty-quick@2.0.1:
     mri "^1.1.4"
     multimatch "^4.0.0"
 
-prisma2@2.0.0-preview016.2:
-  version "2.0.0-preview016.2"
-  resolved "https://registry.yarnpkg.com/prisma2/-/prisma2-2.0.0-preview016.2.tgz#36f3e9cf8f1e44215df4ab9347033b32563d21d0"
-  integrity sha512-K/xnzfpuAiISUGAkqEAvVXRfMe6DyJWTT0Nk8xaTspc3ymm3nU35PR49DeqX839WMTb5tXLnzyi3hgi+074Jwg==
+prisma2@^2.0.0-preview018:
+  version "2.0.0-preview018"
+  resolved "https://registry.yarnpkg.com/prisma2/-/prisma2-2.0.0-preview018.tgz#ff44fe3e4997b20d7816406c0cbaadaf13e83dc8"
+  integrity sha512-OB1jPk1QyMtJH9juxLzFsH7Alh2IqqZbC7jpGdHH6pJAVFGs86tPj5dxr2m9zNZHa8RrrcMMA0La1xqwY6YQjQ==
 
 probot@9.6.6:
   version "9.6.6"


### PR DESCRIPTION
Right now if the output is specified, prisma is being generated to a yarn workspace module and our script is trying to grab the dependency from the root.

I just removed the output path now as `@prisma/photon` now can be added to package.json and managed by yarn workspace itself so that it can be hoisted at the root node_modules.

PS: I also removed the yarn installation command in docker. You were doing it twic e.